### PR TITLE
Fixed some spacing and fixed a bug with Internet Explorer CSS Hacks

### DIFF
--- a/_hacks.scss
+++ b/_hacks.scss
@@ -9,7 +9,7 @@
 
 	Example:
 
-	@include only_ie9( '.my_element', (color: red))
+	@include only_ie9( '.my_element', (color: red) )
 	@include only_ff28_above( '.my_element', (
 		background-color: green,
 		display: flex,
@@ -71,7 +71,7 @@
 /*--- Only Firefox ---*/
 @mixin only_ff($selector, $map){
 	@-moz-document url-prefix() {
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -81,7 +81,7 @@
 
 /*--- Only Firefox 1.5 and Firefox 2 ---*/
 @mixin only_ff2($selector, $map){
-	body:empty #{$selector}{
+	body:empty #{$selector} {
 		@each $property, $value in ($map) {
 			#{$property}: $value;
 		}
@@ -112,7 +112,7 @@
 
 /*--- Only Firefox ≥ 6 ---*/
 @mixin only_ff6_above($selector, $map){
-	_::-moz-progress-bar, body:last-child #{$selector}{
+	_::-moz-progress-bar, body:last-child #{$selector} { 
 		@each $property, $value in ($map) {
 			#{$property}: $value;
 		}
@@ -122,7 +122,7 @@
 /*--- Only Firefox ≥ 16 ---*/
 @mixin only_ff16_above($selector, $map){
 	@supports (-moz-appearance:meterbar){
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -132,7 +132,7 @@
 
 /*--- Only Firefox ≥ 21 ---*/
 @mixin only_ff21_above($selector, $map){
-	_::-moz-range-track, body:last-child #{$selector}{
+	_::-moz-range-track, body:last-child #{$selector} {
 		@each $property, $value in ($map) {
 			#{$property}: $value;
 		}
@@ -142,7 +142,7 @@
 /*--- Only Firefox ≥ 24 ---*/
 @mixin only_ff24_above($selector, $map){
 	@supports (-moz-appearance:meterbar) and (cursor:zoom-in){
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -153,7 +153,7 @@
 /*--- Only Firefox ≥ 25 ---*/
 @mixin only_ff25_above($selector, $map){
 	@supports (-moz-appearance:meterbar) and (background-attachment:local){
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -164,7 +164,7 @@
 /*--- Only Firefox ≥ 26 ---*/
 @mixin only_ff26_above($selector, $map){
 	@supports (-moz-appearance:meterbar) and (image-orientation:90deg){
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -175,7 +175,7 @@
 /*--- Only Firefox ≥ 27 ---*/
 @mixin only_ff27_above($selector, $map){
 	@supports (-moz-appearance:meterbar) and (all:initial){
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -186,7 +186,7 @@
 /*--- Only Firefox ≥ 28 ---*/
 @mixin only_ff28_above($selector, $map){
 	@supports (-moz-appearance:meterbar) and (list-style-type:japanese-formal){
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -197,7 +197,7 @@
 /*--- Only Firefox ≥ 30 ---*/
 @mixin only_ff30_above($selector, $map){
 	@supports (-moz-appearance:meterbar) and (background-blend-mode:difference,normal){
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -215,7 +215,7 @@
 /*--- Only Webkit (Chrome, Safari, Opera ≥ 14) ---*/
 @mixin only_webkit($selector, $map){
 	.selector:not(*:root) {
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -226,7 +226,7 @@
 /*--- Only Chrome 28+, Opera ≥ 14 ---*/
 @mixin only_chrome($selector, $map){
 	@media all and (-webkit-min-device-pixel-ratio:0) and (min-resolution: .001dpcm) {
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -253,7 +253,7 @@
 /*--- Only Safari ≥ 9 ---*/
 @mixin only_safari9($selector, $map){
 	@supports (overflow:-webkit-marquee) and (justify-content:inherit){
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -264,7 +264,7 @@
 /*--- Only iOS Safari ≥ 9 ---*/
 @mixin only_ios($selector, $map){
 	@supports (-webkit-text-size-adjust:none) and (not (-ms-accelerator:true)) and (not (-moz-appearance:none)){
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -273,7 +273,7 @@
 }
 /*--- Only Safari ≥ 9 (Non iOS) ---*/
 @mixin only_safari_no_ios($selector, $map){
-	_:-webkit-full-screen:not(:root:root),#{$selector}{
+	_:-webkit-full-screen:not(:root:root),#{$selector} {
 		@each $property, $value in ($map) {
 			#{$property}: $value;
 		}
@@ -282,7 +282,7 @@
 
 /*--- Only Opera ≤ 9.27, Safari ≤ 2 ---*/
 @mixin only_opera9_safari2($selector, $map){
-	#{'html:first-child '} #{$selector}{
+	#{'html:first-child '} #{$selector} {
 		@each $property, $value in ($map) {
 			#{$property}: $value;
 		}
@@ -298,7 +298,7 @@
 
 /*--- Only Opera ≥ 9.5 ---*/
 @mixin only_opera($selector, $map){
-	_:-o-prefocus, body:last-child #{$selector}{
+	_:-o-prefocus, body:last-child #{$selector} {
 		@each $property, $value in ($map) {
 			#{$property}: $value;
 		}
@@ -308,7 +308,7 @@
 /*--- Only Opera ≤ 11 ---*/
 @mixin only_opera11($selector, $map){
 	@media all and (-webkit-min-device-pixel-ratio:10000), not all and (-webkit-min-device-pixel-ratio:0){
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -322,9 +322,9 @@
 
 @mixin only_edge($selector, $map){
 	@supports (-ms-accelerator:true) {
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
-				#{$property} : $value;
+				#{$property}: $value;
 			}
 		}
 	}
@@ -336,43 +336,49 @@
 
 /*--- Only IE ≤ 6 ---*/
 @mixin only_ie6($selector, $map){
-	#{$selector}{
-		@each $property, $value in ($map) {
-			#{'* html '}+#{$property}: $value;
+	#{$selector} {
+		#{'* html '} {
+			@each $property, $value in ($map) {
+				#{$property}: $value;
+			}
 		}
 	}
 }
 
 /*--- Only IE7 ---*/
 @mixin only_ie7($selector, $map){
-	#{$selector}{
-		@each $property, $value in ($map) {
-			#{'*+html '}+#{$property}: $value;
+	#{$selector} {
+		#{'*+html '} {
+			@each $property, $value in ($map) {
+				#{$property}: $value;
+			}
 		}
 	}
 }
 
 /*--- Only IE ≤ 7 ---*/
 @mixin only_ie7_below($selector, $map){
-	#{$selector}{
-		@each $property, $value in ($map) {
-			#{'*'}+#{$property}: $value;
+	#{$selector} {
+		#{'*'} {
+			@each $property, $value in ($map) {
+				#{$property}: $value;
+			}
 		}
 	}
 }
 
 /*--- Only IE8 ---*/
 @mixin only_ie8($selector, $map){
-	#{$selector}{
+	#{$selector} {
 		@each $property, $value in ($map) {
-			#{$property} : $value+\0#{'/'};
+			#{$property}: $value+\0#{'/'};
 		}
 	}
 }
 
 /*--- Only IE ≤ 8 ---*/
 @mixin only_ie8_below($selector, $map){
-	#{$selector}{
+	#{$selector} {
 		@each $property, $value in ($map) {
 			#{$property}: $value+#{\9};
 		}
@@ -381,7 +387,7 @@
 
 /*--- Only IE9 ---*/
 @mixin only_ie9($selector, $map){
-	#{$selector}{
+	#{$selector} {
 		@each $property, $value in ($map) {
 			#{$property}: $value+#{\9\0};
 		}
@@ -390,7 +396,7 @@
 
 /*--- Only IE ≤ 9 ---*/
 @mixin only_ie9_below($selector, $map){
-	html[lang=\en] #{$selector}{
+	html[lang=\en] #{$selector} {
 		@each $property, $value in ($map) {
 			#{$property}: $value;
 		}
@@ -400,7 +406,7 @@
 /*--- Only IE10 ---*/
 @mixin only_ie10_above($selector, $map){
 	@media all and (-ms-high-contrast:none){
-		*::-ms-backdrop, #{$selector}{
+		*::-ms-backdrop, #{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -411,7 +417,7 @@
 /*--- Only IE ≤ 11 ---*/
 @mixin only_ie11($selector, $map){
 	@media all and (-ms-high-contrast:none){
-		*::-ms-backdrop, #{$selector}{
+		*::-ms-backdrop, #{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value+\0;
 			}
@@ -421,7 +427,7 @@
 
 /*--- Only IE ≥ 11 ---*/
 @mixin only_ie11_above($selector, $map){
-	#{'_:-ms-fullscreen, :root '} #{$selector}{
+	#{'_:-ms-fullscreen, :root '} #{$selector} {
 		@each $property, $value in ($map) {
 			#{$property}: $value;
 		}
@@ -430,7 +436,7 @@
 
 /*--- Anything but IE6 ---*/
 @mixin no_ie6($selector, $map){
-	#{'html>body '} #{$selector}{
+	#{'html>body '} #{$selector} {
 		@each $property, $value in ($map) {
 			#{$property}: $value;
 		}
@@ -440,7 +446,7 @@
 /*--- Only IE ≥ 9, safari4, android ≥ 2.3 ---*/
 @mixin only_ie9_saf4_above($selector, $map){
 	@media screen and (min-width:0\0) {
-		#{$selector}{
+		#{$selector} {
 			@each $property, $value in ($map) {
 				#{$property}: $value;
 			}
@@ -456,7 +462,7 @@
 @mixin no_ie_safari6($selector, $map){
 	@media screen {
 		@media (min-width: 0px) {
-			#{$selector}{
+			#{$selector} {
 				@each $property, $value in ($map) {
 					#{$property}: $value;
 				}


### PR DESCRIPTION
For the Internet Explorer CSS hacks, there was a bug I found when compiling `_hacks.scss` with Ruby Sass. The `#{'* html '}` and `#{'*'}` were inside the `@each` and caused the compiler to error out.

I'm not sure why but it still compiled when using libsass.
